### PR TITLE
JOSM mirror: drop evil revision hack

### DIFF
--- a/josm-mirror.sh
+++ b/josm-mirror.sh
@@ -18,10 +18,6 @@ git config user.email "openstreetmap@v.nix.is"
 git add .
 git commit -m"josm-mirror: bumped externals" || :
 
-# Evil revision hack
-perl -pi -e 's[<arg value="."/>][<arg value="http://josm.openstreetmap.de/svn/trunk"/>]g' build.xml
-git commit -m"josm-mirror: evil build.xml revision hack" build.xml || :
-
 # Push the mirror to GitHub
 git remote add mirror git@github.com:openstreetmap/josm.git || :
 


### PR DESCRIPTION
Since openstreetmap/josm@8528769, JOSM can be built from a git mirror directly.

Also, openstreetmap/josm@bcbc70e should be reverted for a clean and updated build file.
